### PR TITLE
Updates for compatibility with OneWire

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -25,6 +25,21 @@ impl DelayUs<u16> for Ets {
     }
 }
 
+impl DelayMs<u32> for Ets {
+    fn delay_ms(&mut self, ms: u32) {
+        unsafe {
+            ets_delay_us(ms * 1000);
+        }
+    }
+}
+
+impl DelayMs<u16> for Ets {
+    fn delay_ms(&mut self, ms: u16) {
+        DelayMs::<u32>::delay_ms(self, ms as u32);
+    }
+}
+
+
 /// FreeRTOS-based delay provider
 pub struct FreeRtos;
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -156,7 +156,7 @@ pub enum DriveStrength {
 macro_rules! impl_hal_input_pin {
     ($pxi:ident: $mode:ident) => {
         impl embedded_hal::digital::v2::InputPin for $pxi<$mode> {
-            type Error = Infallible;
+            type Error = EspError;
 
             fn is_high(&self) -> Result<bool, Self::Error> {
                 Ok(unsafe {gpio_get_level($pxi::<$mode>::pin())} != 0)
@@ -287,6 +287,7 @@ macro_rules! impl_input_output {
         }
 
         impl_hal_input_pin!($pxi: InputOutput);
+        impl_hal_output_pin!($pxi: InputOutput);
         impl_hal_output_pin!($pxi: Output);
         impl_pull!($pxi: Input);
         impl_pull!($pxi: InputOutput);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -11,7 +11,7 @@
 //! IO can be done inside the peripheral instead of having to be done upfront.
 
 use {
-    core::{convert::Infallible, marker::PhantomData},
+    core::marker::PhantomData,
     embedded_hal::digital::v2::{OutputPin as _, StatefulOutputPin as _},
 };
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -110,7 +110,7 @@ where
             esp_result!(i2c_master_cmd_begin(
                 I2C::port(),
                 command_link.0,
-                self.timeout.into()), ())
+                self.timeout), ())
         }
     }
 }


### PR DESCRIPTION
These changes were all that was required to make this work with OneWire via the `one_wire_bus` crate; all GPIO appears to work fine thereafter.

- Implement `DelayMs` for the `Ets` delay provider
- Implement `OutputPin` as well as the existing `InputPin` for `Gpioxx<InputOutput>` to satisfy the `T: InputPin + OutputPin` constraint
- Use the same `Error` type for both `InputPin` and `OutputPin`. I'm conflicted about this last one; I can see why `InputPin` was considered `Infallible`, and perhaps this should be raised against the driver crate, but on the other hand when using a pin in `InputOutput` mode it makes sense not to have two Error types.